### PR TITLE
Fix token and user data retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Make a config.json file in the config/ folder from the sample given:
 {
     "client_id": "",
     "team_id": "",
-    "redirect_uri": "",
-    "key_id": ""
+    "key_id": "",
+    "redirect_uri": "https://example.com/auth",
+    "scope": "name email"
 }
 ```
 

--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -1,6 +1,7 @@
 {
     "client_id": "",
     "team_id": "",
-    "redirect_uri": "",
-    "key_id": ""
+    "key_id": "",
+    "redirect_uri": "https://apple-auth.example.com/auth",
+    "scope": "name email"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-auth-example",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,8 +14,8 @@
       }
     },
     "apple-auth": {
-      "version": "git+https://github.com/AnandChowdhary/apple-auth.git#091c74f520bb9187421576ceca1f3e1f795663e5",
-      "from": "git+https://github.com/AnandChowdhary/apple-auth.git#patch-1",
+      "version": "git+https://github.com/ananay/apple-auth.git#674a0166c30cff259264d0ff70fe68a40e0258f1",
+      "from": "git+https://github.com/ananay/apple-auth.git",
       "requires": {
         "axios": "^0.19.0",
         "express": "^4.17.1",
@@ -446,9 +446,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "send": {
       "version": "0.17.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "author": "Ananay Arora <i@ananayarora.com> (https://ananayarora.com)",
   "license": "ISC",
   "dependencies": {
-    "apple-auth": "git+https://github.com/ananay/apple-auth"
+    "apple-auth": "git+https://github.com/ananay/apple-auth",
+    "body-parser": "^1.19.0",
+    "jsonwebtoken": "^8.5.1"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,8 @@ const app = express();
 const fs = require('fs');
 const config = fs.readFileSync('./config/config.json');
 const AppleAuth = require('apple-auth');
+const bodyParser = require('body-parser');
+const jwt = require('jsonwebtoken');
 
 let auth = new AppleAuth(config, './config/AuthKey.p8');
 
@@ -15,11 +17,22 @@ app.get('/token', (req, res) => {
     res.send(auth._tokenGenerator.generate());
 });
 
-app.get('/auth', async (req, res) => {
+app.post('/auth', bodyParser(), async (req, res) => {
     try {
         console.log( Date().toString() + "GET /auth");
-        const accessToken = await auth.accessToken(req.query.code);
-        res.json(accessToken);
+        const response = await auth.accessToken(req.body.code);
+        const idToken = jwt.decode(response.id_token);
+
+        const user = {};
+        user.id = idToken.sub;
+
+        if (idToken.email) user.email = idToken.email;
+        if (req.body.user) {
+            const { name } = JSON.parse(req.body.user);
+            user.name = name;
+        }
+
+        res.json(user);
     } catch (ex) {
         console.error(ex);
         res.send("An error occurred!");


### PR DESCRIPTION
This PR fixes the example to retrieve user data. It requires the current version of apple-auth (the one that already uses `form_post`, not yet released).

- `scope: "name email"` has to be set in the configuration
- The `email` is transmitted as part of the ID Token (a JSON Web Token)
- The `name` is transmitted as part of a JSON encoded `user` property via HTTP POST, **and is transmitted only at the first login**. You need to unauthorize the App in you Apple ID settings to be able to re-transmit it!

After successful login, this example outputs a JSON string that looks like this

```json
{
  "id": "012345.0123456789abcdef0123456789abcdef.0123",
  "email": "user@example.com",
  "name": {
    "firstName":"Nico",
    "lastName":"Appleseed"
  }
}
```